### PR TITLE
Solicitar ubicación y mostrar en resultados

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -5,6 +5,9 @@ CREATE TABLE IF NOT EXISTS reclamos (
     category VARCHAR(50) NOT NULL,
     description TEXT NOT NULL,
     photo_path VARCHAR(255) NOT NULL,
+    latitude DOUBLE PRECISION,
+    longitude DOUBLE PRECISION,
+    address TEXT,
     created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
 );
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -50,7 +50,7 @@ app.get('/api/reclamos', async (req, res) => {
   try {
     // Fetch all complaints ordered by creation date desc
     const complaintsResult = await pool.query(
-      'SELECT id, category, description, photo_path, created_at FROM reclamos ORDER BY created_at DESC'
+      'SELECT id, category, description, photo_path, latitude, longitude, address, created_at FROM reclamos ORDER BY created_at DESC'
     );
 
     // Fetch counts per category
@@ -75,7 +75,7 @@ app.get('/api/reclamos', async (req, res) => {
  * Creates a new complaint. Expects `category` and `description` fields and a file `photo`.
  */
 app.post('/api/reclamos', upload.single('photo'), async (req, res) => {
-  const { category, description } = req.body;
+  const { category, description, latitude, longitude, address } = req.body;
   const file = req.file;
 
   // Validate input
@@ -86,8 +86,8 @@ app.post('/api/reclamos', upload.single('photo'), async (req, res) => {
   try {
     const photoPath = '/uploads/' + file.filename;
     const insertResult = await pool.query(
-      'INSERT INTO reclamos (category, description, photo_path, created_at) VALUES ($1, $2, $3, NOW()) RETURNING id, category, description, photo_path, created_at',
-      [category, description, photoPath]
+      'INSERT INTO reclamos (category, description, photo_path, latitude, longitude, address, created_at) VALUES ($1, $2, $3, $4, $5, $6, NOW()) RETURNING id, category, description, photo_path, latitude, longitude, address, created_at',
+      [category, description, photoPath, latitude, longitude, address]
     );
     res.status(201).json(insertResult.rows[0]);
   } catch (err) {

--- a/frontend/src/components/FormPage.js
+++ b/frontend/src/components/FormPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 // Página con el formulario para reportar problemas en la calle
 function FormPage() {
@@ -6,6 +6,27 @@ function FormPage() {
   const [description, setDescription] = useState('');
   const [photo, setPhoto] = useState(null);
   const [message, setMessage] = useState('');
+  const [location, setLocation] = useState({ latitude: null, longitude: null, address: '' });
+
+  useEffect(() => {
+    if (!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition(
+      async (pos) => {
+        const { latitude, longitude } = pos.coords;
+        setLocation((prev) => ({ ...prev, latitude, longitude }));
+        try {
+          const res = await fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${latitude}&lon=${longitude}`);
+          const data = await res.json();
+          setLocation({ latitude, longitude, address: data.display_name });
+        } catch (err) {
+          console.error('Error obteniendo dirección', err);
+        }
+      },
+      (err) => {
+        console.error('Error obteniendo ubicación', err);
+      }
+    );
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -18,6 +39,13 @@ function FormPage() {
     formData.append('category', category);
     formData.append('description', description);
     formData.append('photo', photo);
+    if (location.latitude && location.longitude) {
+      formData.append('latitude', location.latitude);
+      formData.append('longitude', location.longitude);
+    }
+    if (location.address) {
+      formData.append('address', location.address);
+    }
 
     try {
       const res = await fetch('/api/reclamos', {
@@ -67,6 +95,9 @@ function FormPage() {
           onChange={(e) => setPhoto(e.target.files[0])}
           required
         />
+        {location.address && (
+          <p className="address">Ubicación detectada: {location.address}</p>
+        )}
         <button type="submit">Enviar</button>
       </form>
       {message && <p className="message">{message}</p>}

--- a/frontend/src/components/ResultsPage.js
+++ b/frontend/src/components/ResultsPage.js
@@ -52,6 +52,15 @@ function ResultsPage() {
             <div className="complaint-details">
               <h4>{getLabel(complaint.category)}</h4>
               <p>{complaint.description}</p>
+              {complaint.address && <p className="address">{complaint.address}</p>}
+              {complaint.latitude && complaint.longitude && (
+                <iframe
+                  title={`map-${complaint.id}`}
+                  width="100%"
+                  height="200"
+                  src={`https://www.openstreetmap.org/export/embed.html?layer=mapnik&marker=${complaint.latitude},${complaint.longitude}`}
+                ></iframe>
+              )}
               <small>
                 {new Date(complaint.created_at).toLocaleDateString()} {new Date(complaint.created_at).toLocaleTimeString()}
               </small>


### PR DESCRIPTION
## Summary
- Add latitude, longitude and address fields to complaints
- Capture user location and reverse geocode in the report form
- Show reported location and map on the results page

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ad0639ccb4833383f57009417bc552